### PR TITLE
Bump pytest to patched release (>=9.0.3)

### DIFF
--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -18,7 +18,7 @@ dependencies:
   - wandb>=0.19,<1
   - tqdm>=4.67
   - pandas>=2.2,<3.0
-  - pytest>=8.3,<9.0
+  - pytest>=9.0.3,<10.0
   - pytest-mock>=3.14,<4.0
   # ffmpeg is required for torchaudio
   - ffmpeg>=6,<7

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -18,7 +18,7 @@ dependencies:
   - wandb>=0.19,<1
   - tqdm>=4.67
   - pandas>=2.2,<3.0
-  - pytest>=8.3,<9.0
+  - pytest>=9.0.3,<10.0
   - pytest-mock>=3.14,<4.0
   # ffmpeg is required for torchaudio
   - ffmpeg>=6,<7

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -10,7 +10,7 @@ numpy>=2
 wandb>=0.19,<1
 tqdm>=4.67
 pandas>=2.2,<3.0
-pytest>=8.3,<9.0
+pytest>=9.0.3,<10.0
 pytest-mock>=3.14,<4.0
 requests
 -e .

--- a/requirements_gpu_cu118.txt
+++ b/requirements_gpu_cu118.txt
@@ -10,7 +10,7 @@ numpy>=2
 wandb>=0.19,<1
 tqdm>=4.67
 pandas>=2.2,<3.0
-pytest>=8.3,<9.0
+pytest>=9.0.3,<10.0
 pytest-mock>=3.14,<4.0
 requests
 -e .

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ setup(
         'wandb>=0.19,<1',
         'tqdm>=4.67',
         'pandas>=2.2,<3.0',
-        'pytest>=8.3,<9.0',
+        'pytest>=9.0.3,<10.0',
         'pytest-mock>=3.14,<4.0',
         'requests'
     ],


### PR DESCRIPTION
### Motivation
- `pip-audit` reported security advisory `PYSEC-2026-1845` for `pytest` 8.x and a patched release is available in `pytest` 9.0.3.
- Update dependency constraints to remove the flagged vulnerable `pytest` release across pip and conda manifests.

### Description
- Replace `pytest>=8.3,<9.0` with `pytest>=9.0.3,<10.0` in `requirements_cpu.txt`, `requirements_gpu_cu118.txt`, `environment_cpu.yml`, `environment_gpu.yml`, and `setup.py`.
- Commit the changes and prepare PR metadata for review.

### Testing
- Initial `python -m pip_audit -r requirements_cpu.txt` under the default Python (3.14) failed due to wheel / distribution mismatches for `torch`/`torchvision` (installation error), so a follow-up run used Python 3.11.15 to avoid that environment issue.
- `PYENV_VERSION=3.11.15 python -m pip_audit -r requirements_cpu.txt` completed and reported "No known vulnerabilities found" while noting that `edansa`, `torch`, `torchvision`, and `torchaudio` could not be audited because they were not resolved on PyPI.
- `PYENV_VERSION=3.11.15 python -m pip_audit -r requirements_gpu_cu118.txt` completed and reported "No known vulnerabilities found" while noting the same non-audited packages; `git diff --check` returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60d0dd17048332a2c8a1ffc1d9aeef)