### PR TITLE
Bump PyTorch/Torchaudio to 2.10+, switch GPU wheels to CUDA 12.8, and update Python range

### DIFF
--- a/docs/common/troubleshooting.md
+++ b/docs/common/troubleshooting.md
@@ -46,7 +46,7 @@ This page lists common issues encountered when installing or running the EDANSA 
     *   **Missing Backend:** `torchaudio` needs a backend library like FFmpeg to load audio. 
         *   If using Conda with `environment.yml`, `ffmpeg` should have been installed. Verify using `python -c "import torchaudio; print(torchaudio.list_audio_backends())"`. If `ffmpeg` isn't listed, try reinstalling the environment or explicitly installing ffmpeg: `conda install ffmpeg -c conda-forge`.
         *   If using Pip, you likely need to install `ffmpeg` (or `sox`, `libsndfile`) using your system's package manager (Refer to the [official torchaudio documentation on optional dependencies](https://docs.pytorch.org/audio/stable/installation.html#optional-dependencies) for more details). 
-        *   **Important FFmpeg Version Note:** `torchaudio` versions compatible with PyTorch 2.6 do not work correctly with FFmpeg 7.x. It is **strongly recommended to install an FFmpeg 6.x or 5.x version.**
+        *   **Important FFmpeg Version Note:** `torchaudio` versions compatible with PyTorch 2.10 do not work correctly with FFmpeg 7.x. It is **strongly recommended to install an FFmpeg 6.x or 5.x version.**
         *   **Linux/macOS Examples:**
             *   `sudo apt update && sudo apt install ffmpeg` (Check the version provided by your distribution. If it's 7.x, you may need to find `ffmpeg-6` or `ffmpeg-5` packages, or install from a PPA/source that provides an older version).
             *   `brew install ffmpeg@6` (or `ffmpeg@5` if `ffmpeg@6` is not available or if you prefer an older stable version).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This guide covers how to set up the necessary environment and install the EDANSA
 
 *   **Git:** You need Git installed to clone the repository. You can download it from [git-scm.com](https://git-scm.com/).
 *   **(Recommended) Micromamba/Mamba or Conda:** For managing environments and dependencies, we strongly recommend Micromamba or Mamba for significantly faster performance. Standard Conda (from Miniconda or Anaconda) can also be used. If you need to install one, see the [Micromamba installation guide](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html) or the [Miniconda documentation](https://docs.conda.io/en/latest/miniconda.html).
-*   **(Optional) Python:** If not using Conda, you'll need Python installed (version >= 3.8 and < 3.12).
+*   **(Optional) Python:** If not using Conda, you'll need Python installed (version >= 3.10 and < 3.15).
 *   **(GPU Users) NVIDIA Drivers:** If you intend to use a GPU, ensure you have appropriate NVIDIA drivers installed *before* creating the conda environment.
 
 ## Step 1: Clone the Repository
@@ -68,19 +68,19 @@ This method uses `pip` and specific `requirements_*.txt` files to install depend
     ```
 
 2.  **Install Dependencies using Pip:**
-    Choose the requirements file that matches your system (CPU or GPU with CUDA 11.8). Then, run the `pip install -r` command. This will install PyTorch, Torchvision, Torchaudio from the correct PyTorch index, all other dependencies, and the EDANSA package in editable mode.
+    Choose the requirements file that matches your system (CPU or GPU with CUDA 12.8). Then, run the `pip install -r` command. This will install PyTorch, Torchvision, Torchaudio from the correct PyTorch index, all other dependencies, and the EDANSA package in editable mode.
 
     *   **For CPU-only systems:**
         ```bash
         pip install -r requirements_cpu.txt
         ```
 
-    *   **For GPU-enabled systems (CUDA 11.8):**
-        Ensure your NVIDIA drivers are installed and compatible with CUDA 11.8.
+    *   **For GPU-enabled systems (CUDA 12.8):**
+        Ensure your NVIDIA drivers are installed and compatible with CUDA 12.8.
         ```bash
-        pip install -r requirements_gpu_cu118.txt
+        pip install -r requirements_gpu_cu128.txt
         ```
-        *   **Important for CUDA users:** If you are installing for GPU, you must ensure you have the correct NVIDIA drivers and the corresponding CUDA Toolkit (version 11.8 in this case) installed *manually* on your system. `pip` only installs the PyTorch library compiled for that CUDA version, not the CUDA Toolkit itself.
+        *   **Important for CUDA users:** If you are installing for GPU, you must ensure you have the correct NVIDIA drivers and the corresponding CUDA Toolkit (version 12.8 in this case) installed *manually* on your system. `pip` only installs the PyTorch library compiled for that CUDA version, not the CUDA Toolkit itself.
 
     This single command handles all Python package installations.
 

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -3,11 +3,11 @@ channels:
   - defaults
 dependencies:
   # Python requirement
-  - python>=3.8,<3.12
+  - python>=3.10,<3.15
 
   # Core ML Dependencies
-  - pytorch>=2.6,<3 # CPU-only build
-  - torchvision>=0.21,<0.22 # Will pick up CPU variant
+  - pytorch>=2.10,<3 # CPU-only build
+  - torchvision>=0.25,<0.26 # Will pick up CPU variant
   - pytorch-ignite>=0.5,<0.6
   
   # Other Dependencies
@@ -28,5 +28,5 @@ dependencies:
 
   - pip:
       # Install FFmpeg-enabled torchaudio from official PyTorch wheel for CPU
-      - torchaudio --index-url https://download.pytorch.org/whl/cpu
+      - torchaudio>=2.10,<3 --index-url https://download.pytorch.org/whl/cpu
       - -e .

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -3,11 +3,11 @@ channels:
   - defaults
 dependencies:
   # Python requirement
-  - python>=3.8,<3.12
+  - python>=3.10,<3.15
 
   # Core ML Dependencies
-  - pytorch-gpu>=2.6,<3
-  - torchvision>=0.21,<0.22
+  - pytorch-gpu>=2.10,<3
+  - torchvision>=0.25,<0.26
   - pytorch-ignite>=0.5,<0.6
   
   # Other Dependencies
@@ -28,5 +28,5 @@ dependencies:
 
   - pip:
       # Install FFmpeg-enabled torchaudio from official PyTorch wheel
-      - torchaudio --index-url https://download.pytorch.org/whl/cu118
+      - torchaudio>=2.10,<3 --index-url https://download.pytorch.org/whl/cu128
       - -e .

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.6,<3
-torchvision>=0.21,<0.22
-torchaudio>=2.6,<3
+torch>=2.10,<3
+torchvision>=0.25,<0.26
+torchaudio>=2.10,<3
 PyYAML>=6.0,<7.0
 pytorch-ignite>=0.5,<0.6
 scikit-learn>=1.6,<1.7

--- a/requirements_gpu_cu128.txt
+++ b/requirements_gpu_cu128.txt
@@ -1,7 +1,7 @@
---extra-index-url https://download.pytorch.org/whl/cu118
-torch>=2.6,<3
-torchvision>=0.21,<0.22
-torchaudio>=2.6,<3
+--extra-index-url https://download.pytorch.org/whl/cu128
+torch>=2.10,<3
+torchvision>=0.25,<0.26
+torchaudio>=2.10,<3
 PyYAML>=6.0,<7.0
 pytorch-ignite>=0.5,<0.6
 scikit-learn>=1.6,<1.7

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ here = pathlib.Path(__file__).parent.resolve()
 # Get the long description from the README file
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 
-# Requirements are now handled by requirements_cpu.txt and requirements_gpu_cu118.txt for local/dev installs.
+# Requirements are now handled by requirements_cpu.txt and requirements_gpu_cu128.txt for local/dev installs.
 # For `pip install edansa` (e.g. from PyPI), core dependencies are listed below.
 # PyTorch and its variants should be installed by the user separately or via the specific requirements files.
 
@@ -138,9 +138,9 @@ setup(
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
     
     # mostly constrained by torch and torchaudio
-    # torch 2.6.0 requires python 3.8-3.11
-    # https://pytorch.org/audio/2.6.0/installation.html#compatibility-matrix
-    python_requires='>=3.8, <3.12',
+    # torch 2.10.0 requires Python versions supported by the selected PyTorch wheel
+    # https://pytorch.org/audio/stable/installation.html#compatibility-matrix
+    python_requires='>=3.10, <3.15',
 
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is


### PR DESCRIPTION
### Motivation
- Raise the minimum PyTorch/Torchaudio versions to address a reported security advisory and ensure users install a non-vulnerable PyTorch baseline (2.10+). 
- Align the GPU pip index and requirements with PyTorch 2.10 wheels built for CUDA 12.8 and update environment/packaging Python guidance accordingly. 
- Update installation and troubleshooting docs to reflect the new dependency and platform guidance.

### Description
- Updated `requirements_cpu.txt` and renamed/updated `requirements_gpu_cu128.txt` to require `torch>=2.10,<3`, `torchaudio>=2.10,<3`, and `torchvision>=0.25,<0.26` and to point the extra-index to the CUDA 12.8 wheel index. 
- Reworked `environment_cpu.yml` and `environment_gpu.yml` to require `python>=3.10,<3.15`, pin `pytorch`/`pytorch-gpu` to `>=2.10,<3`, bump `torchvision` to `>=0.25,<0.26`, and install `torchaudio>=2.10,<3` from the appropriate wheel index. 
- Updated packaging metadata/comments in `setup.py` to reference `requirements_gpu_cu128.txt` and set `python_requires='>=3.10, <3.15'`. 
- Updated docs (`docs/installation.md`, `docs/common/troubleshooting.md`, and README references) to mention CUDA 12.8 guidance, the new requirements filename, Python range, and torchaudio/FFmpeg compatibility notes. 
- Replaced occurrences of the old CUDA 11.8 / cu118 references with CUDA 12.8 / cu128 where appropriate and added the torchaudio pin to the conda `pip` entries.

### Testing
- Ran `python -m py_compile setup.py` to validate `setup.py` syntax, which succeeded. 
- Validated `environment_cpu.yml` and `environment_gpu.yml` parse as YAML using `yaml.safe_load`, which succeeded. 
- Parsed `requirements_cpu.txt` and `requirements_gpu_cu128.txt` to verify expected requirement entries were present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60d7aef83083329bd53fdbaacf1dcf)